### PR TITLE
Migrate from utils to cliutils

### DIFF
--- a/rax_scheduled_images_python_novaclient_ext/__init__.py
+++ b/rax_scheduled_images_python_novaclient_ext/__init__.py
@@ -25,6 +25,11 @@ from novaclient import base
 from novaclient import exceptions
 from novaclient import utils
 
+try:
+    from novaclient.openstack.common import cliutils
+except ImportError:
+    cliutils = utils
+
 
 DAYS=['sunday', 'monday', 'tuesday', 'wednesday',
       'thursday', 'friday', 'saturday']
@@ -96,7 +101,7 @@ def _find_server(cs, server):
     return utils.find_resource(cs.servers, server)
 
 
-@utils.arg('server', metavar='<server>', help='Name or ID of server.')
+@cliutils.arg('server', metavar='<server>', help='Name or ID of server.')
 def do_scheduled_images_show(cs, args):
     """Show the scheduled image settings for a server"""
     server_id = _find_server(cs, args.server).id
@@ -109,10 +114,10 @@ def do_scheduled_images_show(cs, args):
     print("Retention: %s" % result.retention)
 
 
-@utils.arg('server', metavar='<server>', help='Name or ID of server.')
-@utils.arg('retention', metavar='<retention>', type=int,
+@cliutils.arg('server', metavar='<server>', help='Name or ID of server.')
+@cliutils.arg('retention', metavar='<retention>', type=int,
            help='Number of scheduled images to retain')
-@utils.arg('--day-of-week', default=None, metavar='day',
+@cliutils.arg('--day-of-week', default=None, metavar='day',
            help='If given, the day of week to create a weekly schedule '
                 'for. If omitted, create a daily schedule. Valid values are: '
                 '%s' % str(DAYS))
@@ -126,7 +131,7 @@ def do_scheduled_images_enable(cs, args):
         server_id, args.retention, day_of_week=day_of_week)
 
 
-@utils.arg('server', metavar='<server>', help='Name or ID of server.')
+@cliutils.arg('server', metavar='<server>', help='Name or ID of server.')
 def do_scheduled_images_disable(cs, args):
     """Disable scheduled images for a server"""
     server_id = _find_server(cs, args.server).id


### PR DESCRIPTION
Novaclient migrated from its utils to openstack's cliutils for some
things a year ago (commit id 871c5fc1) and recently removed the
aliases from utils (commit id 96a124fa) causing AttributeError
exceptions, so follow novaclient's example and migrate from utils to
cliutils where applicable.

Just in case someone is using this with a year older novaclient
release, if importing cliutils fails, then alias it to utils.